### PR TITLE
Disable mixed line ending fix in pre-commit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: mixed-line-ending
-        args: [--fix=lf]
+        args: [--fix=no]
       - id: check-yaml
         args: [--allow-multiple-documents]
       - id: check-added-large-files


### PR DESCRIPTION
Fixes #12. 
Given a standard configuration on Windows (`autocrlf` globally enabled), keeping only the `.gitattributes` file with `text=auto` ensures that text files are checked in with LF endings.
To prevent `pre-commit` to create the app from the template, when automatically enabled, we should only check for mixed line ending and not enforce LF endings, as the working copy on Windows will be only composed of CRLF ones.
The only downside of this solution is that mixed line endings should be resolved manually.