### PR TITLE
fix: use included time extension

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -30,7 +30,7 @@
       false
    ],
    "_extensions": [
-      "jinja2_time.TimeExtension",
+      "cookiecutter.extensions.TimeExtension",
       "local_extensions.CustomTargetExtension"
    ]
 }


### PR DESCRIPTION
instead of Jinja2 one.

See https://cookiecutter.readthedocs.io/en/stable/advanced/template_extensions.html#template-extensions